### PR TITLE
Improved tests for running processes; bugfix of "bl-conky-session --autostart"

### DIFF
--- a/README
+++ b/README
@@ -14,5 +14,7 @@ made for CrunchBang Linux and subsequently modified for BunsenLabs.
 
 bl-conkyzen     :
 bl-conky-session:
+bl-conkyedit    :
 bl-tint2zen     :
-bl-tint-session :       Conky and Tint2 Chooser scripts
+bl-tint-session :
+bl-tin2edit     :       Conky and Tint2 Chooser and Editor scripts

--- a/bl-conky-session
+++ b/bl-conky-session
@@ -34,26 +34,32 @@ findArgs(){     # get command args (switches & sessionfile paths)
             arg="$SESSIONFILE"
         fi
         if [[ $arg = "--autostart" ]];then
-            arg="$SESSIONFILE"
             NOKILL=1    # run from autostart, so don't ask to kill conkys
         fi
-        if test -f  "$arg" &>/dev/null;then # sessionfile exists
+        if [ -f  "$arg" ] &>/dev/null;then # sessionfile exists
             rawArr[$i]="$arg"       # add sessionfiles to array
             i=$(($i+1))
-        else
-            echo -e "ERROR: sessionfile \"$arg\" not found. Using default" >&2
-            conky -q 
-            exit 0
         fi
     done
-    # remove duplicate args
-    sessArr=(`printf "%s\n" "${rawArr[@]}" | sort -u`)
-    if [[ $NOKILL == 0 ]];then
-        killConkys
+    # check if sessionfiles were passed to bl-conky-session
+    if ! [ ${#rawArr[@]} -eq 0 ]; then
+        # remove duplicate args
+        sessArr=(`printf "%s\n" "${rawArr[@]}" | sort -u`)
+        if [[ $NOKILL == 0 ]];then
+            killConkys
+        fi
+        for SESSION in "${sessArr[@]}";do # run the conkys in the sessionfiles
+            source "$SESSION"
+        done
+    else    # --autostart used, but no sessionfiles passed to bl-conkyzen
+        if [ -f "$SESSIONFILE" ] && [[ $NOKILL = 1 ]];then
+            source "$SESSIONFILE"   # use conky-sessionfile
+        else
+            echo -e "ERROR: sessionfile \"$SESSIONFILE\" not found. Using default" >&2
+            conky -c $HOME/.conkyrc     # run default conky
+            exit 0
+        fi
     fi
-    for SESSION in "${sessArr[@]}";do # run the conkys in the sessionfiles
-        source "$SESSION"
-    done
 }
 
 killConkys(){

--- a/bl-conkyzen
+++ b/bl-conkyzen
@@ -63,15 +63,42 @@ USAGE2=$(echo -e "\vUSAGE:\tbl-conkyzen [OPTION]...FILES"
 conkyRunning(){    # find running conkys
     > "$TEMPFILE" # make blank tempfile, to save running conky paths
     if [ "$(pidof conky)" ];then
-        ps aux | grep [c]onky" -c" |  awk  '{print $NF}' >> "$TEMPFILE"
+        # test if default conky was started
+        for ARG in $(ps aux | grep  [c]onky | awk '{print $(NF-1)}');do
+            if [[ $ARG = "conky" ]]; then
+                echo "$CRC" >> "$TEMPFILE"  # 'conky -q' probably used
+            else                            # send conky filepath to tempfile
+                for ARG in $(ps aux | grep  [c]onkyrc | awk '{print $(NF)}');do
+                    if [[ $ARG != "-q" ]];then
+                        echo "$ARG" >> "$TEMPFILE"
+                    fi
+                done
+            fi
+        done
     fi
+    # remove any duplicates in tempfile
+    TEMP2="$CONKYPATH/temp.tmp"
+    awk '!x[$0]++' "$TEMPFILE" > "$TEMP2" && mv "$TEMP2" "$TEMPFILE"
 }
 
 fillArrays(){
-    num="$1"
-    conkysPath[$num]="$2"   # full filepath to conky
-    conkysArr[$num]="$3"    # displayed name: "directory/*conky(rc)" 
-    if grep -qx "$2" "$TEMPFILE";then # if conky is running (read from tempfile)
+    if [[ $1 != 0 ]];then
+        num="$1"    # 1st arg: array index
+    else
+        num=0   # '~/.conkyrc' added to array
+    fi
+
+    if [[ $num == 0 ]];then
+        cPATH="$CRC"
+        cARR="$USER/.conkyrc"
+    else
+        cPATH="$2"   # 2nd arg: full filepath to conky
+        cARR="$3"    # 3rd arg: displayed name: "directory/*conky(rc)" 
+    fi
+
+    conkysPath[$num]="$cPATH"
+    conkysArr[$num]="$cARR"
+    if grep -qx "$cPATH" "$TEMPFILE";then # if conky is running (read from tempfile)
         checkArr[$num]="TRUE"       # make checkmark in dialog
     else
         checkArr[$num]="FALSE"
@@ -82,12 +109,13 @@ findConky(){
 # search dirs for conkys files - looking for "conky" in the name
 # if "*conky(rc)" then display it
 
-num=0
+num=0   # added default .conkyrc
+fillArrays $num "$CRC" "$USER/.conkyrc"
+num=1
 # find files in CONKYPATH with conky in the name
 for x in $(find "$CONKYPATH" -type f );do 
     f=$(basename "$x")    # filename from filepath
-    if [[ $f = *conkyrc ]] || [[ $f = *conky ]];then
-        # filename ends with *conky or *conkyrc
+    if [[ $f = *conkyrc ]] || [[ $f = *conky ]];then    # filename ends with *conky or *conkyrc
         # get directory/conkyname to display in list
         CONKY=$( echo "$x" | awk -F"/" '{print $(NF-1)"/"$NF}')
         fillArrays $num "$x" "$CONKY"
@@ -182,9 +210,10 @@ for ((j=0; j<${#conkysArr[*]}; j++));do
 done
 
 ## Populate zenity dialog from array, get return value(s)
-RET=$(zenity --list --title "BunsenLabs Conky Chooser" --text "Session will be saved to:\n $SESSIONFILE"\
- --checklist --width=400 --height=500 \
-    --column "Select" --column "Conky Name" --separator=":"\
+RET=$(zenity --list --title "BunsenLabs Conky Chooser" \
+    --text "Session will be saved to:\n $SESSIONFILE"\
+    --checklist --width=400 --height=500 \
+    --column "Select" --column "Conky Name" --separator=":" \
     $msg)
 
 if [[ $? == 1 ]]; then # cancel button pressed
@@ -214,7 +243,7 @@ else
                 if [[ $display = $name ]];then
                     echo -e "conky -c $f & sleep 1s" >> "$SESSIONFILE"
                     #start the conky (adjust the sleep time if required)
-                    conky -c "$f" & sleep 0.5s
+                    conky -c "$f" & sleep 1s
                 fi
             done
         done

--- a/bl-tint2zen
+++ b/bl-tint2zen
@@ -28,11 +28,21 @@ TEMPFILE="$TINT2PATH/tint2-temp"
 SESSIONFILE="$TINT2PATH/tint2-sessionfile"
 
 tintRunning(){
-    > $TEMPFILE #make blank tempfile
+    > "$TEMPFILE" # make blank tempfile, to save running tint2 paths
     if [ "$(pidof tint2)" ];then
-        # get last field of output = tint2 filepath; write to tempfile
-        ps aux | grep [t]int2" -c" |  awk  '{print $NF}' >> $TEMPFILE
+        # test if default tint2 was started (exclude dialog in this script from list)
+        for FIELD in $(ps aux | grep -v 'zenity' | grep  [t]int2 | awk '{print $NF}');do
+            if [[ $FIELD = "tint2" ]]; then
+                echo "$TINT2PATH/tint2rc" >> "$TEMPFILE"  # 'tint2' command was used
+            elif    # make sure this script doesn't appear in list
+                ! [[ $(echo "$FIELD" | awk -F '/' '{print $NF}') = "bl-tint2zen" ]];then
+                echo "$FIELD" >> "$TEMPFILE"    # send tint2 filepath to tempfile
+            fi
+        done
     fi
+    # remove any duplicates in tempfile
+    TEMP2="$TINT2PATH/tint2-temp2"
+    awk '!x[$0]++' "$TEMPFILE" > "$TEMP2" && mv "$TEMP2" "$TEMPFILE"
 }
 
 fillArrays(){
@@ -71,7 +81,8 @@ for ((j=0; j<${#tintsArr[*]}; j++));do
 done
 
 ## Populate zenity dialog from array, get return value(s)
-RET=$(zenity --list --title "BunsenLabs Tint2 chooser" --text "Select Tint2s from the list:" --checklist --width=300 --height=300 \
+RET=$(zenity --list --title "BunsenLabs Tint2 chooser" \
+    --text "Select Tint2s from the list:" --checklist --width=350 --height=300 \
     --column "Select" --column "tint2 Name" --separator=":"\
     $msg)
 


### PR DESCRIPTION
Running conkys and tint2s now found from running processes, instead of assumed from reading session file. Also test if default command was used.

`bl-conky-session` was starting duplicate conky processes when `--autostart` was used - fixed
