### PR TITLE
Script corrections and enhancements

### DIFF
--- a/bl-conky-session
+++ b/bl-conky-session
@@ -65,7 +65,7 @@ findArgs(){     # get command args (switches & sessionfile paths)
 killConkys(){
     if pidof conky &>/dev/null; then
         msg="Kill running conkys first?"
-        zenity --question --text="$msg"
+        zenity --question --title="Conky sessionfile" --text="$msg"
         if (( $? == 0 )); then            # kill all conkys
             killall conky && sleep 0.2s
         fi

--- a/bl-conkyedit
+++ b/bl-conkyedit
@@ -53,10 +53,10 @@ for ((j=0; j<${#conkysArr[*]}; j++));do
 done
 
 ## Populate zenity dialog from array, get return value(s)
-RET=$(zenity --list --title "Conky Edit" \
-    --text "Select Conkys to edit from the list\nMultiple Conkys can be chosen" \
+RET=$(zenity --list --title="Conky Edit" \
+    --text="Select Conkys to edit from the list\nMultiple Conkys can be chosen" \
     --checklist --width=400 --height=500 \
-    --column "Select" --column "Conky Name" --separator=":"\
+    --column="Select" --column="Conky Name" --separator=":"\
     $msg)
 
 if [[ $? == 1 ]]; then # cancel button pressed

--- a/bl-conkyzen
+++ b/bl-conkyzen
@@ -133,7 +133,7 @@ writeSessions(){    # save a new sessionfile name for use by a menu
     fi
     if grep -qx "$SESSIONFILE" "$SESSIONS";then # session was previously saved
         if [[ $2 = "-z" ]];then    # input was from input dialog, so ask OK?
-            zenity --question --text "Filename already in use!\n\nOverwrite it?"
+            zenity --question --title="Conky sessionfile" --text "Filename already in use\n\nOverwrite it?"
             if [[ $? = 1 ]];then
                 exit 0
             fi
@@ -177,7 +177,7 @@ for arg in "$@";do
                         --text="Enter name for new saved session file\n(File will be saved in conky dir)" \
                         --title="Conky sessionfile") 
                       if [ -z $SPATH ];then     # entry was empty
-                          zenity --error --text="No file specified for new saved session\n\nExiting..."
+                          zenity --error --title="Conky sessionfile" --text="No file specified for new saved session\n\nExiting..."
                           exit 1
                       else
                           writeSessions "$SPATH" "-z"   # saved session file from input dialog
@@ -229,7 +229,7 @@ while ! [[ $RET ]];do
     fi
     if ! [[ $RET ]];then  # No conkys chosen
         MSG="Nothing returned. Try again?"
-        zenity --question --text "$MSG"
+        zenity --question --title="Conky Chooser" --text="$MSG"
         if [[ $? = 1 ]];then
             # restore previous saved-sessions file
             mv "$SESSIONS.bkp" "$SESSIONS"

--- a/bl-conkyzen
+++ b/bl-conkyzen
@@ -133,7 +133,7 @@ writeSessions(){    # save a new sessionfile name for use by a menu
     fi
     if grep -qx "$SESSIONFILE" "$SESSIONS";then # session was previously saved
         if [[ $2 = "-z" ]];then    # input was from input dialog, so ask OK?
-            zenity --question --title="Conky sessionfile" --text "Filename already in use\n\nOverwrite it?"
+            zenity --question --title="Conky sessionfile" --text="Filename already in use\n\nOverwrite it?"
             if [[ $? = 1 ]];then
                 exit 0
             fi
@@ -228,15 +228,16 @@ while ! [[ $RET ]];do
         exit 0
     fi
     if ! [[ $RET ]];then  # No conkys chosen
-        MSG="Nothing returned. Try again?"
+        MSG="Nothing chosen. Kill Conkys?"
         zenity --question --title="Conky Chooser" --text="$MSG"
         if [[ $? = 1 ]];then
             # restore previous saved-sessions file
             mv "$SESSIONS.bkp" "$SESSIONS"
             rm "$TEMPFILE"
-            exit 0
-        else
             continue
+        else
+            killall conky
+            exit 0
         fi
     else
         > "$SESSIONFILE"    # Create new session file

--- a/bl-conkyzen
+++ b/bl-conkyzen
@@ -173,7 +173,9 @@ for arg in "$@";do
                         exit 1
                       fi
                       ;;
-        -z|-Z       ) SPATH=$(zenity --entry --text="Enter name for new saved session file\n(File will be saved in conky dir)")
+        -z|-Z       ) SPATH=$(zenity --entry \
+                        --text="Enter name for new saved session file\n(File will be saved in conky dir)" \
+                        --title="Conky sessionfile") 
                       if [ -z $SPATH ];then     # entry was empty
                           zenity --error --text="No file specified for new saved session\n\nExiting..."
                           exit 1
@@ -213,10 +215,10 @@ done
 
 while ! [[ $RET ]];do
     ## Populate zenity dialog from array, get return value(s)
-    RET=$(zenity --list --title "BunsenLabs Conky Chooser" \
-        --text "Session will be saved to:\n $SESSIONFILE"\
+    RET=$(zenity --list --title="BunsenLabs Conky Chooser" \
+        --text="Session will be saved to:\n $SESSIONFILE"\
         --checklist --width=400 --height=500 \
-        --column "Select" --column "Conky Name" --separator=":" \
+        --column="Select" --column="Conky Name" --separator=":" \
         $msg)
 
     if [[ $? == 1 ]]; then # cancel button pressed

--- a/bl-conkyzen
+++ b/bl-conkyzen
@@ -216,7 +216,7 @@ done
 while ! [[ $RET ]];do
     ## Populate zenity dialog from array, get return value(s)
     RET=$(zenity --list --title="BunsenLabs Conky Chooser" \
-        --text="Session will be saved to:\n $SESSIONFILE"\
+        --text="Session will be saved to:\n $SESSIONFILE" \
         --checklist --width=400 --height=500 \
         --column="Select" --column="Conky Name" --separator=":" \
         $msg)

--- a/bl-kb
+++ b/bl-kb
@@ -3,7 +3,7 @@
 
 # This script reads the keybinds configuration file ("$HOME/.config/openbox/rc.xml")
 # and writes them to a text file ("$HOME/.config/openbox/kbinds.txt").
-# The script is used by bl-kb-pipemenu to pipe the output to the Openbox menu
+# The script is used by bl-kb-pipemenu to pipe the output to the Openbox menu, or to display keybinds in a separate window
 #
 # Based on a script by wlourf 07/03/2010
 # <http://u-scripts.blogspot.com/2010/03/how-to-display-openboxs-shortcuts.html>
@@ -45,7 +45,7 @@ def cmdargs():
             gui=True
             return gui
         else:
-            msg = "\n\n\tUSAGE: to display keybinds in a text window use 'bl-kb --gui'\n\n"
+            msg = "\n\n\tUSAGE: to display keybinds in a text window use 'bl-kb --gui &>/dev/null'\n\n"
             msg = msg + "\tRunning the script without args will send output to the terminal\n\n"
             print(msg)
             sys.exit()
@@ -94,10 +94,10 @@ def output_keybinds(arrShortcut,gui):
         if gui:     #format output for text window
             if len(execute)>80 :
                 execute=execute[:75]+"....."
-            line = "{:2}".format(i) + "\t" + "{:<15}".format(keybinding)\
+            line = "{:2}".format(i) + "\t" + "{:<16}".format(keybinding)\
             + "\t" + execute
         else:   #format text for pipemenu
-            line = exe + "{:<15}".format(keybinding) + "\t" + execute
+            line = exe + "{:<16}".format(keybinding) + "\t" + execute
         print(line)
         write_file(line)
 
@@ -140,5 +140,5 @@ if __name__ == "__main__":
         sys.exit(1)
 
     if gui:     # output formatted keybinds text in text window
-        os.system("zenity --text-info --title='Openbox Keybinds' --filename=$HOME/.config/openbox/kbinds.txt --width=700 --height=700")
+        os.system("zenity --text-info --title='Openbox Keybinds' --filename=$HOME/.config/openbox/kbinds.txt --width=700 --height=700 --font=Monospace")
 

--- a/bl-kb
+++ b/bl-kb
@@ -140,5 +140,5 @@ if __name__ == "__main__":
         sys.exit(1)
 
     if gui:     # output formatted keybinds text in text window
-        os.system("zenity --text-info --filename=$HOME/.config/openbox/kbinds.txt --width=700 --height=700")
+        os.system("zenity --text-info --title='Openbox Keybinds' --filename=$HOME/.config/openbox/kbinds.txt --width=700 --height=700")
 

--- a/bl-kb
+++ b/bl-kb
@@ -45,7 +45,7 @@ def cmdargs():
             gui=True
             return gui
         else:
-            msg = "\n\n\tUSAGE: to display keybinds in a text window use 'bl-kb.py --gui'\n\n"
+            msg = "\n\n\tUSAGE: to display keybinds in a text window use 'bl-kb --gui'\n\n"
             msg = msg + "\tRunning the script without args will send output to the terminal\n\n"
             print(msg)
             sys.exit()
@@ -128,7 +128,7 @@ if __name__ == "__main__":
     check_txtfile(kb_fpath)
     if gui:      # output formatted keybinds text in text window
         write_file(str(datetime.date.today()) + "\trc.xml KEYBINDS")
-        write_file("---------------------------------------\n")
+        write_file("----------------------------------------------------\n")
 
     if check_rcfile(rc_fpath,"r"):
         keyboard()

--- a/bl-tint2edit
+++ b/bl-tint2edit
@@ -48,10 +48,10 @@ for ((j=0; j<${#tintsArr[*]}; j++));do
 done
 
 ## Populate zenity dialog from array, get return value(s)
-RET=$(zenity --list --title "Tint2 Edit" \
-    --text "Select Tint2s to edit from the list\nMultiple Tint2s can be chosen" \
+RET=$(zenity --list --title="Tint2 Edit" \
+    --text="Select Tint2s to edit from the list\nMultiple Tint2s can be chosen" \
     --checklist --width=400 --height=500 \
-    --column "Select" --column "Tint2 Name" --separator=":"\
+    --column="Select" --column="Tint2 Name" --separator=":"\
     $msg)
 
 if [[ $? == 1 ]]; then # cancel button pressed

--- a/bl-tint2zen
+++ b/bl-tint2zen
@@ -93,9 +93,10 @@ for ((j=0; j<${#tintsArr[*]}; j++));do
 done
 
 ## Populate zenity dialog from array, get return value(s)
-RET=$(zenity --list --title "BunsenLabs Tint2 chooser" \
-    --text "Select Tint2s from the list:" --checklist --width=350 --height=300 \
-    --column "Select" --column "tint2 Name" --separator=":"\
+RET=$(zenity --list --title="BunsenLabs Tint2 chooser" \
+    --text="Select Tint2s from the list:" \
+    --checklist --width=350 --height=300 \
+    --column="Select" --column="tint2 Name" --separator=":"\
     $msg)
 
 if [[ $? == 1 ]]; then # cancel button pressed


### PR DESCRIPTION
Changed old-style zenity commands to match current usage, and be compatible with yad;
Improved output formatting of keybinds;
Enable closing of running conkys, if none chosen in dialog.
