### PR TITLE
Allow overriding the bl-lock LOCK_COMMAND

### DIFF
--- a/bin/bl-lock
+++ b/bin/bl-lock
@@ -7,6 +7,10 @@
 
 LOCK_COMMAND=(light-locker-command -l)
 
+if [ -f /home/$USER/.config/bunsen/bl-lock ]; then
+    . /home/$USER/.config/bunsen/bl-lock
+fi
+
 which ${LOCK_COMMAND[0]} >/dev/null 2>&1 || {
     echo "$0: ${LOCK_COMMAND[0]} no such command." >&2
     exit 1


### PR DESCRIPTION
I would really like to change to slimlock from light-locker with very little to no modification of system files. This allows me to do so, but I can't say if it is the best approach. I am glad to change things around if you feel this might be accepted in some form.

Thanks
