### PR TITLE
bl-aerosnap: rewrite it to use XLib and EWMH

### DIFF
--- a/README.bunsen-wmhacks
+++ b/README.bunsen-wmhacks
@@ -1,10 +1,51 @@
 README imported from bunsen-wmhacks
 ===================================
 
-Scripts for adding hot corners and aero style window snapping
-to Openbox.
+Scripts for adding hot corners and aero style window snapping to Openbox,
+or any somewhat EWMH-compliant, reparenting window manager.
 Based on cb-wmhacks, written for CrunchBang Linux.
-Repackaged for BunsenLabs Linux.
+Repackaged and rewritten for BunsenLabs Linux.
+
+### bl-aerosnap usage:
+This script intends to add aero style window snapping to Openbox, or any
+somewhat EWMH-compliant, reparenting window manager. The EWMH hints required for
+proper operation are:
+
+* _NET_ACTIVE_WINDOW
+* _NET_WM_PID
+* _NET_WM_STATE
+ * _NET_WM_STATE_MAXIMIZED
+ * _NET_WM_STATE_MAXIMIZED_VERT
+ * _NET_WM_STATE_MAXIMIZED_HORZ
+* _NET_MOVERESIZE_WINDOW
+* _NET_WORKAREA
+* _NET_FRAME_EXTENTS
+
+This script is designed to be called via Openbox keyboard shortucts.
+Edit Openbox's rc.xml file to add new shortcuts. Example shortcuts to
+bind snapping to Super+Alt+Left/Right key combinations:
+<keybind key="W-A-Left">
+  <action name="Execute">
+    <command>bl-aerosnap --left</command>
+  </action>
+</keybind>
+<keybind key="W-A-Right">
+  <action name="Execute">
+    <command>bl-aerosnap --right</command>
+  </action>
+</keybind>
+
+#### Command line usage:
+bl-aerosnap: usage:
+  --help     show this message and exit
+  --left     attempt to snap the active window to the left of the screen
+  --right    attempt to snap the active window to the right of the screen
+  --top      attempt to snap the active window to the top of the screen
+  --bottom   attempt to snap the active window to the bottom of the screen
+
+All flags function as a toggle, meaning that passing --left twice
+first snaps the active window to the left of the screen and then
+restores it to its original position.
 
 ### bl-hotcorner usage:
 This script is designed to be started automatically on login via
@@ -12,6 +53,7 @@ Openbox's autostart file:
 
 # Start hotcorner detection:
 bl-hotcorners --daemon &
+
 Once started, the script will detect when the mouse cursor enters
 the corners of your screen. If the corner has an associated command,
 it will get executed.
@@ -28,33 +70,14 @@ On first use, a config file will be created
 self-explanatory.
 
 ### bl-aerosnap usage:
-This script is designed to be called via Openbox keyboard shortucts.
-Edit Openbox's rc.xml file to add new shortcuts. Example shortcuts to
-bind snapping to Super+Alt+Left/Right key combinations:
-<keybind key="W-A-Left">
-<action name="Execute">
-<command>bl-aerosnap --left</command>
-</action>
-</keybind>
-<keybind key="W-A-Right">
-<action name="Execute">
-<command>bl-aerosnap --right</command>
-</action>
-</keybind>
-
-#### Command line usage:
-bl-aerosnap: usage:
---help show this message and exit
---left attempt to snap active window to left of screen
---right attempt to snap active window to right of screen
 
 ### Dependencies
 * python
 * python-xlib
-* wmctrl
 * xdotool (>=2.20110530)
+
 On Debian systems:
-sudo apt-get update && sudo apt-get install python python-xlib wmctrl xdotool
+sudo apt-get update && sudo apt-get install python python-xlib xdotool
 
 ### License
 GPL3

--- a/bin/bl-aerosnap
+++ b/bin/bl-aerosnap
@@ -1,139 +1,299 @@
-#!/usr/bin/env python2.7
-#
-#    bl-aerosnap: a script for adding aero style window snapping to Openbox.
-#    Copyright (C) 2012 Philip Newborough   <corenominal@corenominal.org>
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-#    Renamed for BunsenLabs
+#!/usr/bin/env python
 
-from subprocess import Popen, PIPE, STDOUT
-import sys, time, os, re
-import argparse
+"""bl-aerosnap intends to add aero style window snapping to Openbox, or any
+somewhat EWMH-compliant, reparenting window manager. The EWMH hints required
+for proper operation are:
+    * _NET_ACTIVE_WINDOW
+    * _NET_WM_PID
+    * _NET_WM_STATE
+      * _NET_WM_STATE_MAXIMIZED
+      * _NET_WM_STATE_MAXIMIZED_VERT
+      * _NET_WM_STATE_MAXIMIZED_HORZ
+    * _NET_MOVERESIZE_WINDOW
+    * _NET_WORKAREA
+    * _NET_FRAME_EXTENTS
 
-history = '/tmp/bl-aerosnap-'+str(os.getuid())
-windows = {}
-check_intervall = 0.2
+bl-aerosnap was originally written for CrunchBang Linux <http://crunchbang.org/>
+by Philip Newborough <corenominal@corenominal.org>. It is repackaged for
+BunsenLabs by John Crawley and rewritten for BunsenLabs to use Xlib/EWMH instead
+of subprocesses by Jente Hidskes <hjdskes@gmail.com>."""
 
-p = Popen(['xdotool','getdisplaygeometry'], stdout=PIPE, stderr=STDOUT)
-Dimensions = p.communicate()
-Dimensions = Dimensions[0].replace('\n', '')
-Dimensions = Dimensions.split(' ')
-width = int(Dimensions[0])
-height = int(Dimensions[1])
-hw = width / 2
-rt = width - 1
-bt = height - 1
-aeroLcommand="wmctrl -r :ACTIVE: -b add,maximized_vert && wmctrl -r :ACTIVE: -b remove,maximized_horz && wmctrl -r :ACTIVE: -e 0,0,0,"+str(hw)+",-1"
-aeroRcommand="wmctrl -r :ACTIVE: -b add,maximized_vert && wmctrl -r :ACTIVE: -b remove,maximized_horz && wmctrl -r :ACTIVE: -e 0,"+str(hw)+",0,"+str(hw)+",-1"
+# TODO:
+# 1. windows with an originally negative position will not be able to be
+#    restored, see https://gist.github.com/Unia/df288b42c2d60504256b1674af810749
+#    for a traceback.
 
+from Xlib import X, display, protocol
+import argparse, os, sys, tempfile
 
-if os.path.exists(history) == False:
-    f = open(history,'w')
-    f.close()
+# A dict mapping window IDs (see get_window_id below) to that window's geometry
+# and snap direction, if any.
+WINDOWS = {}
 
-def is_root_window():
-    p = Popen(['xdotool', 'getactivewindow'], stdout=PIPE, stderr=STDOUT)
-    ID = p.communicate()
-    if len(ID[0]) > 50:
-        return True
+# TODO(Python3): replace with an actual enum.
+class Snap(object):
+    """This class is here to mimic an enum, which is absent in python 2."""
+    Left, Right, Top, Bottom = range(4)
 
-def window_id():
-    p = Popen(['xdotool', 'getactivewindow'], stdout=PIPE)
-    ID = p.communicate()
-    ID = int(ID[0])
-    p = Popen(['xdotool', 'getwindowpid', str(ID)], stdout=PIPE)
-    PID = p.communicate()
-    PID = int(PID[0])
-    return str(ID)+'-'+str(PID)
+# This class is based on code from the pyewmh project. The library itself is not
+# being used directly because it is not packaged in Debian and we, the
+# BunsenLabs authors, want to stay as close to vanilla Debian as possible. Below
+# follows an excerpt from pyewmh's documentation.
+class EWMH(object):
+    """This module intends to provide an implementation of Extended Window Manager Hints, based on
+    the Xlib modules for python. It provides the ability to get and set properties defined by the
+    EWMH spec.
 
-def window_lookup():
-    ID = window_id()
-    windows = history_load()
-    if windows.has_key(ID):
-        return True
+    :param _dpy: the display to use. If not given, Xlib.display.Display() is used."""
 
-def window_geometry(ID):
-    ID = ID.split('-')
-    p = Popen(['xdotool', 'getwindowgeometry', ID[0]], stdout=PIPE)
-    p = p.communicate()
-    Pos = re.search(r'\d+,\d+', p[0])
-    Size = re.search(r'\d+x\d+', p[0])
-    if Pos and Size:
-        Pos = Pos.group().split(',')
-        Size = Size.group().split('x')
-        return Pos[0]+'|'+Pos[1]+'|'+Size[0]+'|'+Size[1]
+    def __init__(self, _dpy=None):
+        self.dpy = _dpy or display.Display()
+        self.root = self.dpy.screen().root
 
-def window_store():
-    ID = window_id()
-    windows[ID] = window_geometry(ID)
-    s = ID +'|'+window_geometry(ID)+'\n'
-    f = open(history,'a')
-    f.write(s)
-    f.close()
+    def _get_property(self, win, prop):
+        """Gets an X Window's property, or None."""
+        atom = win.get_full_property(self.dpy.intern_atom(prop), X.AnyPropertyType)
+        if atom:
+            return atom.value
+        return None
 
-def window_restore(width):
-    ID = window_id()
-    G = windows[ID].split('|')
-    command = 'wmctrl -r :ACTIVE: -b remove,maximized_vert && '
-    #FIXME: adjust horizontal placement, not sure where this discrepancy comes from?
-    AdjustT = int(G[1]) - 40
-    command += 'wmctrl -r :ACTIVE: -e 0,'+G[0]+','+str(AdjustT)+','+G[2]+','+G[3]
-    del windows[ID]
-    if len(windows) == 0:
-        o = ''
+    def _set_property(self, win, prop, data, mask=None):
+        """Sends a ClientMessage event to an X Window."""
+        if isinstance(data, str):
+            datasize = 8
+        else:
+            data = (data+[0]*(5-len(data)))[:5]
+            datasize = 32
+
+        event = protocol.event.ClientMessage(window=win,
+                                             client_type=self.dpy.intern_atom(prop),
+                                             data=(datasize, data))
+
+        if not mask:
+            mask = (X.SubstructureRedirectMask|X.SubstructureNotifyMask)
+        self.dpy.screen().root.send_event(event, event_mask=mask)
+        self.dpy.flush()
+
+    def set_window_state(self, win, action, state, state2=0):
+        """Sets or unsets one or two state(s) for the given window. (property _NEW_WM_STATE)
+
+        :param win: the X Window object whose state to set
+        :param action: 0 to remove, 1 to add or 2 to toggle state(s)
+        :param state: a state
+        :type state: int or str (see the EWMH spec)
+        :param state2: a state or 0
+        :type state2: int or str (see the EWMH spec)"""
+        if isinstance(state, int) is False:
+            state = self.dpy.intern_atom(state, 1)
+        if isinstance(state2, int) is False:
+            state2 = self.dpy.intern_atom(state2, 1)
+        self._set_property(win, '_NET_WM_STATE', [action, state, state2, 1])
+
+    def set_move_resize_window(self, win, gravity=0, x=None, y=None, width=None, height=None):
+        """Set the property _NET_MOVERESIZE_WINDOW to move or resize the given window.
+        Flags are automatically calculated if x, y, w or h are defined.
+
+        :param win: the X Window object to move and resize
+        :param gravity: gravity (one of the Xlib.X.*Gravity constant or 0)
+        :param x: int or None
+        :param y: int or None
+        :param w: int or None
+        :param h: int or None"""
+        gravity_flags = gravity | 0b0000100000000000 # indicate source (application)
+        if x is None:
+            x = 0
+        else:
+            gravity_flags = gravity_flags | 0b0000010000000000 # indicate presence of x
+        if y is None:
+            y = 0
+        else:
+            gravity_flags = gravity_flags | 0b0000001000000000 # indicate presence of y
+        if width is None:
+            width = 0
+        else:
+            gravity_flags = gravity_flags | 0b0000000100000000 # indicate presence of w
+        if height is None:
+            height = 0
+        else:
+            gravity_flags = gravity_flags | 0b0000000010000000 # indicate presence of h
+        self._set_property(win, '_NET_MOVERESIZE_WINDOW',
+                           [gravity_flags, int(x), int(y), int(width), int(height)])
+
+    def get_active_window(self):
+        """Returns the currently active window, or None. (property _NET_ACTIVE_WINDOW)"""
+        window = self._get_property(self.dpy.screen().root, '_NET_ACTIVE_WINDOW')
+        if window is None:
+            return None
+        return self.dpy.create_resource_object('window', window[0])
+
+    def get_window_pid(self, win):
+        """Returns the PID of the process owning the X Window, or 0. (property _NET_WM_PID)
+
+        :param win: the X Window object whose owning proces' PID to retrieve"""
+        prop = self._get_property(win, '_NET_WM_PID')
+        if prop:
+            return prop[0]
+        return 0
+
+    def get_workarea(self):
+        """Returns the work area, which is the size of the screen minus panels and docks and the like."""
+        workarea = self._get_property(self.dpy.screen().root, '_NET_WORKAREA')
+        return workarea[0], workarea[1], workarea[2], workarea[3]
+
+    def get_frame_extents(self, win):
+        """Returns the frame extents of the window's frame.
+
+        :param win: the X Window object whose frame to retrieve"""
+        extents = self._get_property(win, '_NET_FRAME_EXTENTS')
+        return extents[0], extents[1], extents[2], extents[3]
+
+def write_history(history):
+    """Writes the WINDOWS dictionary to history.
+
+    :param history: the file path to write to"""
+    with open(history, 'w') as hist_file:
+        hist_file.write(str(WINDOWS))
+
+def load_history(history):
+    """Loads the history file into the WINDOWS dictionary.
+
+    :param history: the file path to read"""
+    if os.path.exists(history) == False:
+        return
+
+    with open(history, 'r') as hist_file:
+        global WINDOWS
+        WINDOWS = eval(hist_file.read())
+
+def window_restore(ewmh, win):
+    """Restores the passed-in window's geometry from the WINDOWS dictionary.
+
+    :param ewmh: the :class:`EWMH` module to restore the window
+    :param win: the X Window object whose geometry to restore"""
+    win_id = get_window_id(ewmh, win)
+    geom = WINDOWS[win_id]
+    del WINDOWS[win_id]
+
+    ewmh.set_window_state(win, 0, '_NET_WM_STATE_MAXIMIZED_VERT')
+    ewmh.set_window_state(win, 0, '_NET_WM_STATE_MAXIMIZED_HORZ')
+    ewmh.set_move_resize_window(win, x=geom[0], y=geom[1], width=geom[2], height=geom[3])
+
+    print ("Restoring to: " + str(geom[0]) + ' ' + str(geom[1]) + ' ' + str(geom[2]) + ' ' + str(geom[3]))
+
+def window_snap(ewmh, win, snap):
+    """Snaps a window to a position on the screen.
+
+    :param ewmh: the :class:`EWMH` module to snap the window
+    :param win: the X Window object to snap
+    :param snap: the :class:`Snap` value, deciding which direction to snap to"""
+    x, y, width, height = ewmh.get_workarea()
+    frame_left, frame_right, frame_top, frame_bottom = ewmh.get_frame_extents(win)
+
+    geom = get_window_geometry(win)
+    print ("Snapping window from: " + str(geom[0]) + ' ' + str(geom[1]) + ' ' + str(geom[2]) + ' ' + str(geom[3]))
+    ewmh.set_window_state(win, 0, '_NET_WM_STATE_MAXIMIZED_VERT')
+    ewmh.set_window_state(win, 0, '_NET_WM_STATE_MAXIMIZED_HORZ')
+    ewmh.set_window_state(win, 0, '_NET_WM_STATE_MAXIMIZED')
+
+    # TODO(Python3): replace with switch.
+    if snap is Snap.Left:
+        print ("Snapping window to: " + str(x) + " " + str(y) + " " + str(width / 2 - frame_left - frame_right))
+        ewmh.set_window_state(win, 1, '_NET_WM_STATE_MAXIMIZED_VERT')
+        ewmh.set_window_state(win, 0, '_NET_WM_STATE_MAXIMIZED_HORZ')
+        ewmh.set_move_resize_window(win, x=x, y=y, width=width / 2 - frame_left - frame_right)
+    elif snap is Snap.Right:
+        print ("Snapping window to: " + str(width / 2) + ' ' + str(y) + ' ' + str(width / 2 - frame_left - frame_right))
+        ewmh.set_window_state(win, 1, '_NET_WM_STATE_MAXIMIZED_VERT')
+        ewmh.set_window_state(win, 0, '_NET_WM_STATE_MAXIMIZED_HORZ')
+        ewmh.set_move_resize_window(win, x=width / 2, y=y, width=width / 2 - frame_left - frame_right)
+    elif snap is Snap.Top:
+        print ("Snapping window to: " + str(x) + " " + str(y) + " " + str(height / 2 - frame_top - frame_bottom))
+        ewmh.set_window_state(win, 0, '_NET_WM_STATE_MAXIMIZED_VERT')
+        ewmh.set_window_state(win, 1, '_NET_WM_STATE_MAXIMIZED_HORZ')
+        ewmh.set_move_resize_window(win, x=x, y=y, height=height / 2 - frame_top - frame_bottom)
+    elif snap is Snap.Bottom:
+        print ("Snapping window to: " + str(x) + " " + str(height / 2) + ' ' + str(height / 2 - frame_top - frame_bottom))
+        ewmh.set_window_state(win, 0, '_NET_WM_STATE_MAXIMIZED_VERT')
+        ewmh.set_window_state(win, 1, '_NET_WM_STATE_MAXIMIZED_HORZ')
+        ewmh.set_move_resize_window(win, x=x, y=height / 2, height=height / 2 - frame_top - frame_bottom)
+
+def get_window_geometry(win):
+    """Returns a list containing the window's x, y, width and height coordinates in that order.
+
+    :param win: the X Window object"""
+    window_geom = win.get_geometry()
+    parent_geom = win.query_tree().parent.get_geometry()
+    return [parent_geom.x, parent_geom.y, window_geom.width, window_geom.height]
+
+def get_window_id(ewmh, win):
+    """Returns a unique identifier for an X Window, made up of its "to string" and process' PID.
+
+    :param ewmh: the :class:`EWMH` class to retrieve the X Window's process' PID
+    :param win: the X Window object whose identifier to return"""
+    pid = ewmh.get_window_pid(win)
+    return str(win) + "-" + str(pid)
+
+def convert(opts):
+   """Converts the options into the correct enumeration value.
+
+   :param opts: the options resulting from `ap.parse_args`"""
+   if opts.left:
+       return Snap.Left
+   elif opts.right:
+       return Snap.Right
+   elif opts.top:
+       return Snap.Top
+   elif opts.bottom:
+       return Snap.Bottom
+   raise ValueError("Argument must be one of `--left`, `--right`, `--top` or `--bottom`")
+
+def parse_args(argv):
+    """Parses the command line arguments using argparse."""
+    ap = argparse.ArgumentParser(description="Add aero style window snapping to " \
+            "Openbox, or any EWMH compliant, reparenting window manager")
+    ap.add_argument("-l", "--left",
+            help="attempt to snap the active window to the left of the screen",
+            action="store_true")
+    ap.add_argument("-r", "--right",
+            help="attempt to snap the active window to the right of the screen",
+            action="store_true")
+    ap.add_argument("-t", "--top",
+            help="attempt to snap the active window to the top of the screen",
+            action="store_true")
+    ap.add_argument("-b", "--bottom",
+            help="attempt to snap the active window to the bottom of the screen",
+            action="store_true")
+    return ap.parse_args(argv)
+
+def main():
+    opts = parse_args(sys.argv[1:])
+
+    dpy = display.Display()
+    ewmh = EWMH(dpy)
+    active_win = ewmh.get_active_window()
+
+    if dpy.screen().root == active_win:
+        sys.exit(0)
+
+    history = tempfile.gettempdir() + '/bl-aerosnap-' + str(os.getuid())
+    load_history(history)
+
+    snap = convert(opts)
+    wid = get_window_id(ewmh, active_win)
+    if wid in WINDOWS:
+        # The snap direction is the same; restore the window.
+        if snap == WINDOWS[wid][4]:
+            window_restore(ewmh, active_win)
+        # The snap direction is new; overwrite the remembered snap direction and snap to it.
+        else:
+            WINDOWS[wid][4] = snap
+            window_snap(ewmh, active_win, snap)
     else:
-        for key in windows:
-            h = windows[key].split('|')
-            o = key+'|'+h[0]+'|'+h[1]+'|'+h[2]+'|'+h[3]+'\n'
-    f = open(history,'w')
-    f.write(o)
-    f.close()
-    os.system(command)
+        WINDOWS[wid] = get_window_geometry(active_win) + [snap]
+        window_snap(ewmh, active_win, snap)
 
-def history_load():
-    f = open(history,'r')
-    i = 0
-    for line in f:
-        h = line.split('|')
-        h[4] = h[4].replace('\n', '')
-        windows[h[0]] = h[1]+'|'+h[2]+'|'+h[3]+'|'+h[4]
-    f.close()
-    return windows
+    write_history(history)
 
-ap = argparse.ArgumentParser(description="Add aero style window snapping to Openbox")
-ap.add_argument("-l", "--left", help="attempt to snap active window to left of screen",
-            action="store_true")
-ap.add_argument("-r", "--right", help="attempt to snap active window to right of screen",
-            action="store_true")
-opts = ap.parse_args(sys.argv[1:])
+if __name__ == "__main__":
+    main()
 
-# if len(sys.argv) < 2 or sys.argv[1] == "--help":
-#     print_usage()
-
-if opts.left:
-    if is_root_window != True:
-        if window_lookup():
-            window_restore(width)
-        else:
-            window_store()
-            os.system(aeroLcommand)
-
-elif opts.right:
-    if is_root_window != True:
-        if window_lookup():
-            window_restore(width)
-        else:
-            window_store()
-            os.system(aeroRcommand)

--- a/bin/bl-aerosnap
+++ b/bin/bl-aerosnap
@@ -135,6 +135,12 @@ class EWMH(object):
             return prop[0]
         return 0
 
+    def get_viewport(self):
+        """Returns the viewport, which is the x and y coordinates of the top
+        left corner of each desktop."""
+        viewport = self._get_property(self.dpy.screen().root, '_NET_DESKTOP_VIEWPORT')
+        return viewport[0], viewport[1]
+
     def get_workarea(self):
         """Returns the work area, which is the size of the screen minus panels and docks and the like."""
         workarea = self._get_property(self.dpy.screen().root, '_NET_WORKAREA')
@@ -197,25 +203,29 @@ def window_snap(ewmh, win, snap):
 
     # TODO(Python3): replace with switch.
     if snap is Snap.Left:
-        print ("Snapping window to: " + str(x) + " " + str(y) + " " + str(width / 2 - frame_left - frame_right))
+        print ("Snapping window to: x: " + str(x) + " width: " + str(width / 2 - frame_left - frame_right))
         ewmh.set_window_state(win, 1, '_NET_WM_STATE_MAXIMIZED_VERT')
         ewmh.set_window_state(win, 0, '_NET_WM_STATE_MAXIMIZED_HORZ')
-        ewmh.set_move_resize_window(win, x=x, y=y, width=width / 2 - frame_left - frame_right)
+        ewmh.set_move_resize_window(win, x=x, width=width / 2 - frame_left - frame_right)
     elif snap is Snap.Right:
-        print ("Snapping window to: " + str(width / 2) + ' ' + str(y) + ' ' + str(width / 2 - frame_left - frame_right))
+        viewport_x, viewport_y = ewmh.get_viewport()
+        offset_x = x - viewport_x
+        print ("Snapping window to: x: " + str(width / 2 + offset_x) + ' width: ' + str(width / 2 - frame_left - frame_right))
         ewmh.set_window_state(win, 1, '_NET_WM_STATE_MAXIMIZED_VERT')
         ewmh.set_window_state(win, 0, '_NET_WM_STATE_MAXIMIZED_HORZ')
-        ewmh.set_move_resize_window(win, x=width / 2, y=y, width=width / 2 - frame_left - frame_right)
+        ewmh.set_move_resize_window(win, x=width / 2 + offset_x, width=width / 2 - frame_left - frame_right)
     elif snap is Snap.Top:
-        print ("Snapping window to: " + str(x) + " " + str(y) + " " + str(height / 2 - frame_top - frame_bottom))
+        print ("Snapping window to: y: " + str(y) + " height: " + str(height / 2 - frame_top - frame_bottom))
         ewmh.set_window_state(win, 0, '_NET_WM_STATE_MAXIMIZED_VERT')
         ewmh.set_window_state(win, 1, '_NET_WM_STATE_MAXIMIZED_HORZ')
-        ewmh.set_move_resize_window(win, x=x, y=y, height=height / 2 - frame_top - frame_bottom)
+        ewmh.set_move_resize_window(win, y=y, height=height / 2 - frame_top - frame_bottom)
     elif snap is Snap.Bottom:
-        print ("Snapping window to: " + str(x) + " " + str(height / 2) + ' ' + str(height / 2 - frame_top - frame_bottom))
+        viewport_x, viewport_y = ewmh.get_viewport()
+        offset_y = y - viewport_y
+        print ("Snapping window to: y: " +  str(height / 2 + offset_y) + 'height: ' + str(height / 2 - frame_top - frame_bottom))
         ewmh.set_window_state(win, 0, '_NET_WM_STATE_MAXIMIZED_VERT')
         ewmh.set_window_state(win, 1, '_NET_WM_STATE_MAXIMIZED_HORZ')
-        ewmh.set_move_resize_window(win, x=x, y=height / 2, height=height / 2 - frame_top - frame_bottom)
+        ewmh.set_move_resize_window(win, y=height / 2 + offset_y, height=height / 2 - frame_top - frame_bottom)
 
 def get_window_geometry(win):
     """Returns a list containing the window's x, y, width and height coordinates in that order.

--- a/bin/bl-aerosnap
+++ b/bin/bl-aerosnap
@@ -233,6 +233,12 @@ def get_window_geometry(win):
     :param win: the X Window object"""
     window_geom = win.get_geometry()
     parent_geom = win.query_tree().parent.get_geometry()
+    if parent_geom.x < 0:
+        sys.stderr.write("Warning: cannot restore to negative x-coordinate, setting to 0\n")
+        parent_geom.x = 0
+    if parent_geom.y < 0:
+        sys.stderr.write("Warning: cannot restore to negative y-coordinate, setting to 0\n")
+        parent_geom.y = 0
     return [parent_geom.x, parent_geom.y, window_geom.width, window_geom.height]
 
 def get_window_id(ewmh, win):


### PR DESCRIPTION
Using XLib and EWMH directly is a cleaner solution than spawning subprocesses
all the time. Whilst working on this, I made several other changes to improve
the performance and maintainability of bl-aerosnap:
- Remove as much global state as possible;
- Read and write history only once;
- Use `sys.exit` as opposed to just `exit` (https://docs.python.org/2/library/sys.html#sys.exit);
- Use `tempfile` to get the system's temp directory, as opposed to hardcoding `/tmp`;
- Add `--top` and `--bottom` options.

Since I changed the code quite significantly, I wrote a small test script that compares the debug statements (which I'd have to remove prior to this being merged) to see if the behavior is what we want it to be. Note that you should probably change the coordinate strings for your own setup (mine is a 1366x768 laptop monitor with a single panel in the bottom of 30 pixels). I could probably make it setup independent by working with `/tmp/bl-aerosnap-$(id -u)` instead of debug statements, but we're talking about a test script here :stuck_out_tongue_winking_eye:.

``` bash
#!/usr/bin/env sh

# Remove old history, if any
rm "/tmp/bl-aerosnap-$(id -u)"

# Test regular snap/restore, by snapping and restoring the active window 10
# times per snapping direction. If the debug prints are not equal, the test is
# stopped and exists with an exit status of 1.
for i in "left" "right" "top" "bottom"; do
    for j in $(seq 1 10); do
        FROM="$(python bin/bl-aerosnap --$i | grep "from" | cut -c23- -)"
        TO="$(python bin/bl-aerosnap --$i | grep "Restoring" | cut -c15- -)"
        if [ "$FROM" != "$TO" ]; then
            printf "Geometries do not match:\nFrom: %s\nTo: %s\n" "$FROM" "$TO" 1>&2
            exit 1
        fi
    done
done

# Imagine the following scenario: user snaps terminal to the left, but now wants
# it snapped to the right. In this case, several things should happen:
#1. The user should be able to directly snap to the right, without having to
#    restore the window first.
#2. The original position (the one prior to snapping to the left) should be
#    remembered to restore to.
# This piece of code tests whether this happens, by first snapping to the left
# and then to the right. If it works for these two directions and this
# combination, it works for all directions and combinations.
ORIG="$(python bin/bl-aerosnap --left | grep "from" | cut -c23- -)"
RIGHT="$(python bin/bl-aerosnap --right | grep "from" | cut -c23- -)"
if [ "$RIGHT" != "0 0 681 713" ]; then
    printf "Not snapping from the left" 1>&2
    exit 1
fi
TO="$(python bin/bl-aerosnap --right | grep "Restoring" | cut -c15- -)"
if [ "$ORIG" != "$TO" ]; then
    printf "Geometries do not match:\nFrom: %s\nTo: %s\n" "$ORIG" "$TO" 1>&2
    exit 1
fi
```

There is one issue remaining, namely that windows that originally have a negative position will not be able to be restored. Help with this issue would be appreciated, as it looks like it is quite a deep issue. A traceback of this issue is the following:

```
 > ./bin/bl-aerosnap --left
Restoring to: -195 192 790 422
Traceback (most recent call last):
  File "./bin/bl-aerosnap", line 279, in <module>
    main()
  File "./bin/bl-aerosnap", line 262, in main
    window_restore(ewmh, active_win)
  File "./bin/bl-aerosnap", line 183, in window_restore
    ewmh.set_move_resize_window(win, x=geom[0], y=geom[1], width=geom[2], height=geom[3])
  File "./bin/bl-aerosnap", line 128, in set_move_resize_window
    [gravity_flags, int(x), int(y), int(width), int(height)])
  File "./bin/bl-aerosnap", line 78, in _set_property
    data=(datasize, data))
  File "/usr/lib/python3.5/site-packages/Xlib/protocol/rq.py", line 1413, in __init__
    self._binary = self._fields.to_binary(**keys)
  File "/usr/lib/python3.5/site-packages/Xlib/protocol/rq.py", line 1012, in to_binary
    v, l, fm = f.pack_value(field_args[f.name])
  File "/usr/lib/python3.5/site-packages/Xlib/protocol/rq.py", line 707, in pack_value
    data, dlen, fmt = PropertyData.pack_value(self, value)
  File "/usr/lib/python3.5/site-packages/Xlib/protocol/rq.py", line 688, in pack_value
    data = array(array_unsigned_codes[size], val).tostring()
OverflowError: can't convert negative value to unsigned int
```

Another potential issue that I want to point out, is that currently I copied in the relevant bits of [pyewmh](https://github.com/parkouss/pyewmh) because this module is not available as a Debian package. (Don't worry, the licenses are compatible). If preferred, we could probably package this ourselves and just import the upstream code, which is probably cleaner.

Please test this thoroughly, with your funkiest setups (especially multi monitor, as I currently do not have access to my second monitor!)

Looking forward to your feedback!
