### PR TITLE
Better accommodation for Xscreensaver users

### DIFF
--- a/bin/bl-lock
+++ b/bin/bl-lock
@@ -19,9 +19,12 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-LOCK_COMMAND=(light-locker-command -l)
+if [ "$(dpkg-query --show --showformat='${db:Status-Abbrev;2}' xscreensaver 2>/dev/null)" = 'ii' ] &&  [ "$(dpkg-query --show --showformat='${db:Status-Abbrev;2}' light-locker 2>/dev/null)" = 'un' ]
+then LOCK_COMMAND=(xscreensaver-command --lock)
+else LOCK_COMMAND=(light-locker-command -l)
+fi
 
-HELP="    bl-lock a wrapper for the 'light-locker-command -l' command
+HELP="    bl-lock a wrapper for the '${LOCK_COMMAND[*]}' command
 
 Options:
     -h --help   show this message

--- a/bin/bl-lock
+++ b/bin/bl-lock
@@ -20,8 +20,10 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 if [ "$(dpkg-query --show --showformat='${db:Status-Abbrev;2}' xscreensaver 2>/dev/null)" = 'ii' ] &&  [ "$(dpkg-query --show --showformat='${db:Status-Abbrev;2}' light-locker 2>/dev/null)" = 'un' ]
-then LOCK_COMMAND=(xscreensaver-command --lock)
-else LOCK_COMMAND=(light-locker-command -l)
+then
+    LOCK_COMMAND=(xscreensaver-command --lock)
+else
+    LOCK_COMMAND=(light-locker-command -l)
 fi
 
 HELP="    bl-lock a wrapper for the '${LOCK_COMMAND[*]}' command

--- a/debian/bunsen-utilities.postinst
+++ b/debian/bunsen-utilities.postinst
@@ -3,14 +3,13 @@ set -e
 
 #DEBHELPER#
 
-if [ "$(dpkg-query --show --showformat='${db:Status-Abbrev;2}' xscreensaver 2>/dev/null)" = 'ii' ]
+if [ "$(dpkg-query --show --showformat='${db:Status-Abbrev;2}' xscreensaver 2>/dev/null)" = 'ii' ] && [ "$(dpkg-query --show --showformat='${db:Status-Abbrev;2}' light-locker 2>/dev/null)" = 'ii' ]
 then
     echo "
 This package uses light-locker in the bl-lock script.
-You seem to have xscreensaver installed.
+You seem to have xscreensaver and light-locker installed.
 To avoid conflicts, please remove xscreensaver from your
 openbox autostart file, and consider uninstalling it.
-(Alternatively, uninstall light-locker and edit /usr/bin/bl-lock.)
 
 "
     sleep 2


### PR DESCRIPTION
Every time bunsen-utilities updates, it clobbers my edited bl-lock script and breaks my xscreensaver lock. This patch fixes that without breaking the expected behavior for those using light-lock.

I incorporated a variant of the testing logic used in debian/bunsen-utilities.postinst in the bl-lock script to make it use 'xscreensaver-command --lock' as the LOCK_COMMAND if xscreensaver is installed and light-locker is absent. It will default to light-locker in all other conditions.

I updated the test and warning in debian/bunsen-utilities.postinst to only display the warning if xscreensaver *and* light-locker are *both* installed, as the presence of xscreensaver alone is properly  handled by this update to bl-lock.