### PR TITLE
Ignore empty line on loading tint2-sessionfile

### DIFF
--- a/bin/bl-tint2-session
+++ b/bin/bl-tint2-session
@@ -113,6 +113,7 @@ loadSession(){
         safeKill tint2
         set -m
         while read -r path;do
+            [[ -z $path ]] && continue ## ignore empty line
             path=$( fullPath "$path" ) || continue
             tint2 -c "$path" >/dev/null 2>&1 &
             disown


### PR DESCRIPTION


# Ignore empty line on loading tint2-sessionfile


## Description

See [issue #75](https://github.com/BunsenLabs/bunsen-utilities/issues/75).
