### PR TITLE
bin/bl-lock: add wayland compatibility

### DIFF
--- a/bin/bl-lock
+++ b/bin/bl-lock
@@ -20,6 +20,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 LOCK_COMMAND=(light-locker-command -l)
+[[ -n "$WAYLAND_DISPLAY" ]] && LOCK_COMMAND=(gtklock -d)
 
 HELP="bl-lock is a wrapper for the configured screenlock command
 


### PR DESCRIPTION
Adjusted `bl-lock` to use `gtklock` if on wayland. tested on `labwc`. Also tested openbox/X11 to ensure no breakage. 